### PR TITLE
feat(kubernetes): add kustomization and resources for AAP

### DIFF
--- a/kubernetes/sno/apps/aap/aap/app/kustomization.yaml
+++ b/kubernetes/sno/apps/aap/aap/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./subscription.yaml
+  - ./operator-group.yaml

--- a/kubernetes/sno/apps/aap/aap/app/operator-group.yaml
+++ b/kubernetes/sno/apps/aap/aap/app/operator-group.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ansible-automation-platform-operator
+spec:
+  targetNamespaces:
+    - aap

--- a/kubernetes/sno/apps/aap/aap/app/subscription.yaml
+++ b/kubernetes/sno/apps/aap/aap/app/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ansible-automation-platform-operator
+spec:
+  channel: stable-2.4-cluster-scoped
+  installPlanApproval: Automatic
+  name: ansible-automation-platform-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/kubernetes/sno/apps/aap/aap/ks.yaml
+++ b/kubernetes/sno/apps/aap/aap/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ansible-automation-platform
+  namespace: flux-system
+spec:
+  targetNamespace: aap
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/sno/apps/aap/aap/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/sno/apps/aap/kustomization.yaml
+++ b/kubernetes/sno/apps/aap/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml

--- a/kubernetes/sno/apps/aap/namespace.yaml
+++ b/kubernetes/sno/apps/aap/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aap
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Add kustomization configurations and resource definitions for the Ansible Automation Platform (AAP) application within the Kubernetes Single Node OpenShift (SNO) environment. This includes the creation of a new namespace 'aap', operator group, and subscription resources for the AAP operator, as well as the necessary kustomization files to manage the deployment through FluxCD.