### PR TITLE
feat(kubernetes): add cloudnative-pg resources for database management

### DIFF
--- a/kubernetes/sno/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudnative-pg
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudnative-pg-secret
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_USER
+    - secretKey: password
+      remoteRef:
+        key: cloudnative-pg
+        property: POSTGRES_SUPER_PASS
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_ACCESS_KEY_ID
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: cloudnative-pg
+        property: AWS_SECRET_ACCESS_KEY

--- a/kubernetes/sno/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./subscription.yaml

--- a/kubernetes/sno/apps/database/cloudnative-pg/app/subscription.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/app/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cloudnative-pg-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: cloudnative-pg
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/kubernetes/sno/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./kubernetes/main/sno/database/cloudnative-pg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/sno/apps/database/kustomization.yaml
+++ b/kubernetes/sno/apps/database/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./cloudnative-pg/ks.yaml

--- a/kubernetes/sno/apps/database/namespace.yaml
+++ b/kubernetes/sno/apps/database/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Add new Kubernetes manifests for managing the cloudnative-pg application within the database namespace. This includes the creation of an ExternalSecret, a Subscription for the cloudnative-pg operator, and the necessary Kustomization files to orchestrate the deployment and configuration. The ExternalSecret is configured to use a ClusterSecretStore with one password connect, and the Subscription is set up to automatically approve install plans from the certified-operators source in the openshift-marketplace. Additionally, a new Namespace manifest is added with pruning disabled. These changes are part of the ongoing efforts to automate and manage database resources effectively.