### PR TITLE
feat(kustomization): add operator-group resource to cloudnative-pg app

### DIFF
--- a/kubernetes/sno/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./subscription.yaml
+  - ./operator-group.yaml

--- a/kubernetes/sno/apps/database/cloudnative-pg/app/operator-group.yaml
+++ b/kubernetes/sno/apps/database/cloudnative-pg/app/operator-group.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cloudnative-pg-operator
+spec:
+  targetNamespaces:
+    - database


### PR DESCRIPTION
Add the operator-group.yaml to the cloudnative-pg application to specify the target namespaces for the cloudnative-pg-operator.