### PR TITLE
feat(automation-controller): add k8s manifests for automation controller

### DIFF
--- a/kubernetes/sno/apps/aap/automation-controller/app/automation-controller.yaml
+++ b/kubernetes/sno/apps/aap/automation-controller/app/automation-controller.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: automationcontroller.ansible.com/v1beta1
+kind: AutomationController
+metadata:
+  name: automation-controller
+spec:
+  ingress_type: none
+  admin_user: ansible
+  postgres_configuration_secret: automation-controller-secret
+  secret_key_secret: automation-controller-secret

--- a/kubernetes/sno/apps/aap/automation-controller/app/externalsecret.yaml
+++ b/kubernetes/sno/apps/aap/automation-controller/app/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: automation-controller
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: automation-controller-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        host: postgres-rw.database.svc.cluster.local
+        port: "5432"
+        database: awx
+        username: "{{ .AWX_POSTGRES_USER }}"
+        password: "{{ .AWX_POSTGRES_PASSWORD }}"
+        sslmode: prefer
+        type: unmanaged
+
+        secret_key: "{{ .AWX_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: awx
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/sno/apps/aap/automation-controller/app/kustomization.yaml
+++ b/kubernetes/sno/apps/aap/automation-controller/app/kustomization.yaml
@@ -3,6 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./aap/ks.yaml
-  - ./automation-controller/ks.yaml
+  - ./externalsecret.yaml
+  - ./automation-controller.yaml

--- a/kubernetes/sno/apps/aap/automation-controller/ks.yaml
+++ b/kubernetes/sno/apps/aap/automation-controller/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ansible-controller
+  namespace: flux-system
+spec:
+  targetNamespace: aap
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/sno/apps/aap/ansible-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Add Kubernetes manifests for the Automation Controller application, including the main application configuration, external secret definition, and kustomization files for setup with Kustomize. This includes the setup for an ExternalSecret that integrates with a ClusterSecretStore, and the necessary configurations for the AutomationController custom resource. The changes also update the main kustomization.yaml to include the new automation-controller Kustomization.