### PR TITLE
feat(netbox): enhance pod security context configuration

### DIFF
--- a/kubernetes/sno/apps/infra/netbox/app/helmrelease.yaml
+++ b/kubernetes/sno/apps/infra/netbox/app/helmrelease.yaml
@@ -31,6 +31,19 @@ spec:
     envFrom:
       - secretRef:
           name: netbox-secret
+    podSecurityContext:
+      fsGroup: 1000730000
+    securityContext:
+      runAsUser: 1000730000
+      runAsGroup: 1000730000
+      runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     probes:
       liveness: &probes
         enabled: true


### PR DESCRIPTION
Add security context settings to the Netbox HelmRelease to enforce better security practices, including running as non-root, dropping all capabilities, and setting a read-only root filesystem.