### PR TITLE
feat(flux): add reconcile task and integrate Vault HelmRelease

### DIFF
--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -31,3 +31,6 @@ tasks:
       - sops --decrypt {{.OPENSHIFT_DIR}}/{{.cluster}}/bootstrap/flux/age-key.secret.sops.yaml
       - sops --decrypt {{.OPENSHIFT_DIR}}/{{.cluster}}/bootstrap/flux/github-deploy-key.secret.sops.yaml
       - sops --decrypt {{.OPENSHIFT_DIR}}/{{.cluster}}/flux/vars/cluster-secrets.secret.sops.yaml
+  reconcile:
+    desc: Reconcile Flux resources from the git repository
+    cmd: flux reconcile --namespace flux-system kustomization cluster --with-source

--- a/openshift/sno/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/sno/apps/infra/vault/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/hashicorp/vault-helm/main/values.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vault
+spec:
+  interval: 30m
+  chart:
+    spec:
+      # renovate: registryUrl=https://helm.releases.hashicorp.com
+      chart: vault
+      version: 0.28.1
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      enabled: false
+      openshift: true
+    server:
+      enabled: true
+      updateStrategyType: RollingUpdate
+      readinessProbe:
+        enabled: true
+        path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204"
+      dataStorage:
+        enabled: true
+        size: 20Gi
+        mountPath: "/vault/data"
+        accessMode: ReadWriteOnce
+
+      extraEnvironmentVars:
+        TZ: ${TIMEZONE}
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 250m
+        limits:
+          memory: 256Mi
+      standalone:
+        enabled: true
+        config: |
+          log_format = "json"
+          log_level = "debug"
+          ui = true
+          cluster_name = "vault"
+          storage "file" {
+            path = "/vault/data"
+          }
+          # HTTPS listener
+          listener "tcp" {
+            address = "[::]:8200"
+            cluster_address = "[::]:8201"
+            tls_disable = 1
+          }
+          telemetry {
+            prometheus_retention_time = "24h"
+            disable_hostname = true
+          }

--- a/openshift/sno/apps/infra/vault/app/kustomization.yaml
+++ b/openshift/sno/apps/infra/vault/app/kustomization.yaml
@@ -3,5 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./vault/ks.yaml
+  - ./helmrelease.yaml

--- a/openshift/sno/apps/infra/vault/ks.yaml
+++ b/openshift/sno/apps/infra/vault/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vault
+  namespace: flux-system
+spec:
+  targetNamespace: infra
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./openshift/sno/apps/infra/vault/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
- Added a new `reconcile` task to the Taskfile for reconciling Flux resources from the git repository.
- Updated `kustomization.yaml` in `openshift/sno/apps/infra` to include Vault kustomization.
- Created `helmrelease.yaml` for Vault HelmRelease configuration in `openshift/sno/apps/infra/vault/app`.
- Added `kustomization.yaml` in `openshift/sno/apps/infra/vault/app` to manage Vault HelmRelease.
- Introduced `ks.yaml` in `openshift/sno/apps/infra/vault` for Flux Kustomization of Vault resources.