### PR TITLE
feat(route): add annotations for cert-manager and specify host

### DIFF
--- a/openshift/sno/apps/infra/vault/app/route.yaml
+++ b/openshift/sno/apps/infra/vault/app/route.yaml
@@ -3,7 +3,11 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: vault
+  annotations:
+    cert-manager.io/issuer-kind: ClusterIssuer
+    cert-manager.io/issuer-name: letsencrypt-production
 spec:
+  host: "vault.${SECRET_DOMAIN}"
   to:
     kind: Service
     name: vault


### PR DESCRIPTION
- Added annotations for cert-manager to use ClusterIssuer with letsencrypt-production.
- Specified the host for the route using the SECRET_DOMAIN variable.