### PR TITLE
refactor(route): remove cert-manager annotations

### DIFF
--- a/openshift/sno/apps/infra/vault/app/route.yaml
+++ b/openshift/sno/apps/infra/vault/app/route.yaml
@@ -3,9 +3,6 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: vault
-  annotations:
-    cert-manager.io/issuer-kind: ClusterIssuer
-    cert-manager.io/issuer-name: letsencrypt-production
 spec:
   host: "vault.${SECRET_DOMAIN}"
   to:


### PR DESCRIPTION
Removed the cert-manager.io annotations for issuer-kind and issuer-name from the vault route configuration. This change simplifies the route definition by eliminating unnecessary certificate management settings.