### PR TITLE
feat(external-secrets): add initial configuration for external-secrets and onepassword-connect

### DIFF
--- a/openshift/sno/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/openshift/sno/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.9.19
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  values:
+    installCRDs: true
+    serviceMonitor:
+      enabled: true
+      interval: 1m
+    webhook:
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+    certController:
+      serviceMonitor:
+        enabled: true
+        interval: 1m

--- a/openshift/sno/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/openshift/sno/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -3,7 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
-  - ./hashicorp.yaml
-  - ./jetstack.yaml
+  - ./helmrelease.yaml

--- a/openshift/sno/apps/external-secrets/external-secrets/ks.yaml
+++ b/openshift/sno/apps/external-secrets/external-secrets/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./openshift/sno/apps/external-secrets/external-secrets/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app external-secrets-stores
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets
+  path: ./openshift/sno/apps/external-secrets/external-secrets/stores
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/openshift/sno/apps/external-secrets/external-secrets/stores/clustersecretstore.yaml
+++ b/openshift/sno/apps/external-secrets/external-secrets/stores/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/clustersecretstore_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-connect
+spec:
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+      vaults:
+        sno-ops: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-secret
+            key: token
+            namespace: external-secrets

--- a/openshift/sno/apps/external-secrets/external-secrets/stores/kustomization.yaml
+++ b/openshift/sno/apps/external-secrets/external-secrets/stores/kustomization.yaml
@@ -3,7 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
-  - ./hashicorp.yaml
-  - ./jetstack.yaml
+  - ./clustersecretstore.yaml

--- a/openshift/sno/apps/external-secrets/kustomization.yaml
+++ b/openshift/sno/apps/external-secrets/kustomization.yaml
@@ -3,7 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
-  - ./hashicorp.yaml
-  - ./jetstack.yaml
+  - ./namespace.yaml
+  - ./external-secrets/ks.yaml
+  - ./onepassword-connect/ks.yaml

--- a/openshift/sno/apps/external-secrets/namespace.yaml
+++ b/openshift/sno/apps/external-secrets/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/openshift/sno/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
+++ b/openshift/sno/apps/external-secrets/onepassword-connect/app/helmrelease.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onepassword-connect
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.2.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      onepassword-connect:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          api:
+            image:
+              repository: docker.io/1password/connect-api
+              tag: 1.7.2@sha256:6aa94cf713f99c0fa58c12ffdd1b160404b4c13a7f501a73a791aa84b608c5a1
+            env:
+              XDG_DATA_HOME: &configDir /config
+              OP_HTTP_PORT: &apiPort 8080
+              OP_BUS_PORT: 11220
+              OP_BUS_PEERS: localhost:11221
+              OP_SESSION:
+                valueFrom:
+                  secretKeyRef:
+                    name: onepassword-connect-secret
+                    key: 1password-credentials.json
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /heartbeat
+                    port: *apiPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *apiPort
+                  initialDelaySeconds: 15
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources: &resources
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256M
+          sync:
+            image:
+              repository: docker.io/1password/connect-sync
+              tag: 1.7.2@sha256:fe527ed9d81f193d8dfbba4140d61f9e8c8dceb0966b3009259087504e5ff79c
+            env:
+              XDG_DATA_HOME: *configDir
+              OP_HTTP_PORT: &syncPort 8081
+              OP_BUS_PORT: 11221
+              OP_BUS_PEERS: localhost:11220
+              OP_SESSION:
+                valueFrom:
+                  secretKeyRef:
+                    name: onepassword-connect-secret
+                    key: 1password-credentials.json
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /heartbeat
+                    port: *syncPort
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *syncPort
+                  initialDelaySeconds: 15
+            securityContext: *securityContext
+            resources: *resources
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: onepassword-connect
+        ports:
+          http:
+            port: *apiPort
+    persistence:
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: *configDir

--- a/openshift/sno/apps/external-secrets/onepassword-connect/app/kustomization.yaml
+++ b/openshift/sno/apps/external-secrets/onepassword-connect/app/kustomization.yaml
@@ -3,7 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./bjw-s.yaml
-  - ./external-secrets.yaml
-  - ./hashicorp.yaml
-  - ./jetstack.yaml
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/openshift/sno/apps/external-secrets/onepassword-connect/app/secret.sops.yaml
+++ b/openshift/sno/apps/external-secrets/onepassword-connect/app/secret.sops.yaml
@@ -1,0 +1,29 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: onepassword-connect-secret
+stringData:
+    1password-credentials.json: ENC[AES256_GCM,data:LZ5EN/G0xeNrK1ZptK94+gRj8O6YaycsB+28TmiKxDOoyZLuPcu7unq+vxAHb+1R85nSlginJbKURjXGveo9zZdDmNjF9+DYHOjUNPrlFXb4+lebZK2e0H1vI8Xf3JE6RIJLUkr09sbr0aL4EGZrcxsAslEFmsrgfupFZvEKD1Iqx/jEI3OVzfM6nxqLZfkX9yfzVgMYPzyYreMJaiOClA4lksqiTq/4HFNCZDzMZOr3sGAFojQqLk6ruOeXM0HgFEmcDgiOc2QYYYTOEs0gE2u4tiC2C7HKFmYsK9yQt66BrifY5+WtxMO6syWor6G7F2xhB8PKuYZ1TvEwQsR1vEqgiZQk4iLm1DkxufZ1isQ2h/ABJi0kRPNvrW+kCF2QwLRKSBth3G+FPrGBVDRla/WyKsFu71eAkBMX8OfrTDht1gogg8gFEeOlJeseu2EZOfmN3mCUuzd+oiB2/jCiznNSAg4Y6OBT/4nlfR0Y+/KQiCWD4Z09ihEkSMA47Ms8I+jERBAg6M9CvAYi7uVZGEsRkDu/GCPA953Z5rVJRi/yesxaGfZYl5KJ07GAUdH6heBz+UgMeukGb9Q3q6UbtAIX1XlyK05OfwgWeci6K/dKnX5EarzoKEw9LGU3JmfvpS4UZhGh53gWn7CU4sR8xn5kaC5Et+tQpwXbWOW8fwlX4nOvhkSYI4bxhK7raiU9tWLydKuHzHh1OJtzoCocyaYiglXTylfxK1xMTqYpRcxoQGjKTn453RJDyK37W/UuUCGWvvFhoDgdT8QyYRFX7/+tvbdML0E4XShg6umUQaojdof5j47PUagncc4kPG5lt9/jQyB4h/c0K8ofDZLi+pEFooplfXVzAjJcAfnZvkr+mK28wHyVQJZWNTRsOmfaqYhNQfWeNTm7+XqkHbvLR0PPz0O0CCJdcleXXeaSZDlSeBuakDtaF4hjwhhlsWR82sVievSulp4+czTrlB5GVSxDb53beCfzOLIPal4DIANSPd/m6A2LlxIbmtxDQYzNg/Y652y7E/4et/yITy3FC6eWECS8F5YGla4Y9ln/LBCquJm3SBXeKNggZkEwA+8PlItiFXPHo2rqLjB0fYJ98Jj1ZGyDMgYrJ3+FKs8oehTKxJYWgVg+XSsvlwLfA1oAXhMUiEFJvFKEAuIgTISyKMHFgBlRaFHXxtZXYWsUTmvspJjC4Fb66p0H14VecxxrEUgh+81IepjaYqrsfs+zVUcClI8aZRMTRboVZOpRR8XuQMvFnHw/Lqx2bSOiAPCjE6rc6Jr6FNrPqXbTgj9vbRWMbIVnpLaL/vX3qhZ7997juvluckA2IQKgCdcDpGJ5pwwk0/44l5+AA/CjtbNBocRj3mVvqufDy747U4AjKU5kX7atFoWbOAca5v70WxujVzJ2nkgc9POdVoW/gnQgeGTMPPJKU395h8Az3NQecKyChhbYB7wydBYhUOHVu3ksUm6rJyKAZ6nTDZ0Rd5ytt40eGoj51r0dMUPEVusorYRL19Dlq0l9cCpVHZkkK0oIvQAXu3LlFeAAZk6B4uSraH6MzJeqHnWWp5Kq2O0xtmDH+NFAeJwAVLCO0TDFIGXYdID3npR//BS5wS8dorkZWcHhvMGxzhzR0bLIXdda50+/gdQryZM0Ef688hdw5hypgaKeid6h+31UKAtix/D1cjV2gGnn7YHSC3oXoNrrKYYGiSg9dKM02qJ4flIeqvtzcG00s+i0EQGKVHNO9HKFUnI8ggztibdMe2nJd56Y4+fULt+fkZ4VfNf5HjVCGMbi8Riut8v/duk0hSHn1coFDmWzNjfpThVGqcMQ8Cku5oI1v0a6CRQp4DbvUewpxP33QB4wqJjhczxPJVu4QKVKXALLiOQGXcglvheHSavHSCcKzBPLXOKoqC11Rx83bGCLr3UECi/IMSiMIXWC,iv:xfGtjwWIq67o1dyiqQr6824xYy756EL7JJOGhcBNcxs=,tag:O3Vf9M35pIqRoa+erxP3jQ==,type:str]
+    token: ENC[AES256_GCM,data:5meA5FM6ve13+APNpd43OTCckrugxBIuyuTxQMUbZkxTE1GYnz1HgI9eoFlw1HNAbsRLU+tzj79NiSEyBeEh80HS+RzraI2CJY5QgkAnvEa2GNA2FXObThbSELJFq1GEmK7/jHG63cY1jC6eNHZslBg7mkvWKHpjUUYbKoYyd2JUTnWxR+ryltBeX6Pgm9sM1uvc1UqrTVLKQxC3a7C1LIwK4Lol+Dve0kjBuWxiVA4DwJ1xR4FhfLSQ80moIDz3GjSjCXyibXU9RC+4u+cKw/JRjsvgHLGcE3CQMNEoF7Ch1uZ1qH9WQwzc7S//jzr+HDIqL9BnDFbWaWoEff16uvoMtC2zGqTQ9CNFaLszm3VUEWDLB5WmDl8s2/eRxhCmJXdrBHDTTKxrlsY0/yTcW30k16dTRsYht1yzf7t6xm/fEKBPHsJS4hRD+GxtJFA8Q+VCDI9FOIUSAJD+VRovL8TMomgThICETwfoTgwJwz2AsG488BcpSC5ZmQx/UaIrpIB6iDaIPNvAddGyBt9qKHX8WcBPo53YH7e3/vCKwt3YjOsMsuJIOJZ4xZVb9IiIDMScp3wYNtScpCOOD+kegVYGeusr7UhRQKB5Y9mGV8lKfdz3GL8el/abdaiB6KX8wRtZiwlTbOVrek5+xOCghcKRfwNwnqCalHeb9pkWKepp9K29F+pZdqGbqRAJ0xkEbNua65C2BhquDJzOMHgkTbqMIn0760PvTEZsZ6Vf4rzVT5DJB/si9pMx225ANFBc9ZZ2OWvKxVvx8EADzbXjqWkktXeXVmWe9rpAKh8ziIh+R1vb0XrrdXwwFcVpxC9wK0/tgWWFFENueO0FYU9Ih/Fm,iv:dybH+gBhiaIvzEivLdQV1Z0KtAcP2kF1WIIV7TzpyPQ=,tag:M28uFxgA1FkyS5cbbM9qag==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1pq76xc07f94c90a45fc9x9e0ylehplg25wmzrksr0yyamt5t6yfqhew74l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQNEJ0cmtDUnZEUDR0Mm82
+            TkVTa2J2ay9MQllBd0dFYkNiU1FTMXhYdERVCkpLbjMxcEs3V2VLYkNoSVcrZUFz
+            dkJUQm01bUd0Ylh0cjdXNmM2YnRPcTAKLS0tIGRjYXd4THp3OUlvZVlpSzdXMzJu
+            MGZzbkFFSFFubjdpNWdFQjF3aityNE0K9o6ekypnljC/g2FUCEKISw2dkzmRiicD
+            QiuS1y+1R62za1kmDaB+ve6IYTXbasaal5/sN67VRUqWAl2zLHaq+Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-10-07T16:14:19Z"
+    mac: ENC[AES256_GCM,data:Klg57QexlZVAWN++3VVggRHoGv1WBtTHbfB3Q2KefdSg3Xg205CbXuAd/a0aZsu6WyY4p9ypzyKRtoshhwh0TVJKXHq8uMeTGcteN0WvvRVlxH0tQNtZtN+u+Uw9Odf3Z57bIqDQM7g8IIotYHMeI2SE00TUMGhYgQI6wBpQXNU=,iv:wfNQg8xii0Z/v0c7leI02YEDPjZeF+xnuoK6yMi71F8=,tag:xy9gPhD/6sUeeZxRaInyiA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    mac_only_encrypted: true
+    version: 3.9.1

--- a/openshift/sno/apps/external-secrets/onepassword-connect/ks.yaml
+++ b/openshift/sno/apps/external-secrets/onepassword-connect/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app onepassword-connect
+  namespace: flux-system
+spec:
+  targetNamespace: external-secrets
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./openshift/sno/apps/external-secrets/onepassword-connect/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/openshift/sno/flux/repositories/helm/bjw-s.yaml
+++ b/openshift/sno/flux/repositories/helm/bjw-s.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bjw-s
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 5m
+  url: oci://ghcr.io/bjw-s/helm

--- a/openshift/sno/flux/repositories/helm/external-secrets.yaml
+++ b/openshift/sno/flux/repositories/helm/external-secrets.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://charts.external-secrets.io


### PR DESCRIPTION
- Added HelmRelease for external-secrets with monitoring and CRD installation enabled.
- Configured Kustomization for external-secrets and its dependencies.
- Introduced ClusterSecretStore for onepassword-connect with necessary authentication.
- Added HelmRelease for onepassword-connect with specific container configurations and security contexts.
- Included secret.sops.yaml for encrypted secret management.
- Updated flux Helm repositories to include bjw-s and external-secrets.
- Modified kustomization.yaml to include new resources for external-secrets and onepassword-connect.