### PR TITLE
feat(cloudflared): add HelmRelease and Kustomization for cloudflared app

### DIFF
--- a/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
+++ b/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app cloudflared
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.5.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: nginx-external
+      namespace: network
+  values:
+    controllers:
+      cloudflared:
+        replicas: 2
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/cloudflare/cloudflared
+              tag: 2024.9.1@sha256:0b88e00d8f93f9d18197f11506f0f6bf0d9266b5a0361c068930a3fe45b68b72
+            env:
+              NO_AUTOUPDATE: true
+              TUNNEL_METRICS: 0.0.0.0:8080
+              TUNNEL_ORIGIN_ENABLE_HTTP2: true
+              TUNNEL_TRANSPORT_PROTOCOL: quic
+              TUNNEL_POST_QUANTUM: true
+            args:
+              - tunnel
+              - run
+              - --token
+              - "${SECRET_CLOUDFLARE_TUNNEL_SECRET}"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+        pod:
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            runAsNonRoot: true
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+    service:
+      app:
+        controller: cloudflared
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      app:
+        serviceName: cloudflared
+        endpoints:
+          - port: http
+            scheme: http
+            path: /metrics
+            interval: 1m
+            scrapeTimeout: 10s

--- a/openshift/sno/apps/network/cloudflared/app/kustomization.yaml
+++ b/openshift/sno/apps/network/cloudflared/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/openshift/sno/apps/network/cloudflared/ks.yaml
+++ b/openshift/sno/apps/network/cloudflared/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudflared
+  namespace: flux-system
+  labels:
+    substitution.flux.home.arpa/enabled: "true"
+spec:
+  targetNamespace: network
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./openshift/sno/apps/network/cloudflared/app
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: sno-ops
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/openshift/sno/apps/network/kustomization.yaml
+++ b/openshift/sno/apps/network/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  - ./cloudflared/ks.yaml

--- a/openshift/sno/apps/network/namespace.yaml
+++ b/openshift/sno/apps/network/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: network
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/openshift/sno/flux/vars/cluster-secrets.secret.sops.yaml
+++ b/openshift/sno/flux/vars/cluster-secrets.secret.sops.yaml
@@ -5,7 +5,10 @@ metadata:
     namespace: flux-system
 stringData:
     SECRET_CLOUDFLARE_ACCOUNT_ID: ENC[AES256_GCM,data:15Qqr6JKrdmBEFifx+VYXMV2ACsjjciID1zkxdvCUOA=,iv:+u8MN9JMmZh4+G1gDMO2LRhtXV74NHh9DiNpsKCeg4I=,tag:PntobrnLaEynCQMNeMylaA==,type:str]
+    SECRET_CLOUDFLARE_API_KEY: ENC[AES256_GCM,data:TF8s2uwxaLNG1yKLshrl6siXaEaZKY7qGbFmOUniy0c4tcGB+GDcaQ==,iv:JVgWlTuZVD+zhymdOqam4c7JcJpHDPyBzo1KMMa86Qo=,tag:F6mCwFVk1vNtEM7s76O8xw==,type:str]
     SECRET_CLOUDFLARE_EMAIL: ENC[AES256_GCM,data:Y2Xfap0ee5d1I7+4LTI=,iv:xKeiNNKtxf+Uyt0ZXJhmOFzsq6l2yhK+JmY1AHNeonU=,tag:b0w0FIssNRg4VH1XOaDA5w==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_ID: ENC[AES256_GCM,data:Qfdx8Kn0TTBbAUWC6tgxqkxvsbxqszqndojKOZ6/XQMCaVmH,iv:KsrZKDip55PzTRPH0Ww1jskfy3lGuHE2m79C/VMYwBE=,tag:zeNE1+XsV5oNk1j/6y0VRA==,type:str]
+    SECRET_CLOUDFLARE_TUNNEL_SECRET: ENC[AES256_GCM,data:CwdwolhVmu23hYoaBk1028WLwDTbWjMJlZS0oalUHL9fszZPU5BhLhlAjpOv1VKYjjKiwScHIrRHA8VBJiID3qCxWqkspz8jOL5piP5w5y1IHqegPxNHJbQj0nMlu5pK1+1UHiycn33yYBrtDWMpZXSjOFd71CWmqIXpPl/yX/KTz3GX1bewB4ScurRXkyliXl0WF7eNW7U8fJKuMyzTzU/Z7HjX5nnomSE6tHoJKG1P8gTkI2OqYA==,iv:YwtCHuzEsyPUhHQ3hucabW9QRcYrlooJMeye6JcnxX4=,tag:BYsvidAA5aYT5niz4cj3lQ==,type:str]
     SECRET_DOMAIN: ENC[AES256_GCM,data:1Pxi33YCXvze8rJmXlINTA==,iv:+4YRKFG6jj6Fm8Vx+a6pNDEd24X0qc4GRFFXz0yxrCw=,tag:RQ7rXKwnCu5ahVNO1LA3GA==,type:str]
 sops:
     kms: []
@@ -22,9 +25,9 @@ sops:
             ZDdOd3lsTktRSk1vQnNOUy8xdkZ4L1UKiOSkhFrjawDEEZADmQdiFoF8ngorQE2C
             mahtIzRFQj8wOAjthKIZgxYW0796rLny+tN9gcLblStDkWtykIYR2Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-11T21:54:37Z"
-    mac: ENC[AES256_GCM,data:TnITJYObQ2Zkax2eQyhoHbPFhIbpSkwJwXTp8DUvDHPilqN1dU85q6M+sgKzIsCUKm+PJ5hhWtXMNt9+YS4G+S0P7pvPwK1huVdbu+4I9JJAeanPPIKlUwRT285q/4XCMF6muwWzbTwQULi489aFtd18HZxyz29VkLlOd88+Iz4=,iv:/ZDYBTKGorEnABs7W9Y+/tK1fe7wR65dBmzBYu1ndHI=,tag:RXAu6i7hACCccTdgWqjd5Q==,type:str]
+    lastmodified: "2024-10-07T19:06:30Z"
+    mac: ENC[AES256_GCM,data:ZkF/5klTfmnlySTvBHQM3sjMiZGc3461DlJ2tB7fvrl5pRfzrHiDlctixafgYg6TJzcpep+F7rfPxGb7hER3vd5r+bu+WSBxi5UX8UF8xhdSM+qDb0SMfFFDFs6UoEUgVT2KLJTCt8OpIfVo/YdEVZrpnx+uA8VSUN4XOZUpquU=,iv:ciqTaaAdBogJOm5nqF/EYHg9Q2lRDh+i32aBPIBBm4U=,tag:JdP62S2NmORi+zSSaLiJ7g==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     mac_only_encrypted: true
-    version: 3.9.0
+    version: 3.9.1


### PR DESCRIPTION
- Introduced a new HelmRelease for the cloudflared application in the OpenShift SNO environment.
- Configured the HelmRelease with necessary values, including image details, environment variables, and security contexts.
- Added a Kustomization file to manage the cloudflared app resources.
- Updated the cluster-secrets.secret.sops.yaml to include new secrets for Cloudflare tunnel configuration.
- Created a namespace.yaml for the 'network' namespace with annotations to disable pruning.
- Updated the main kustomization.yaml to include the new cloudflared Kustomization.