### PR TITLE
refactor(cloudflared): remove runAsUser and runAsGroup from securityC…

### DIFF
--- a/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
+++ b/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
@@ -69,8 +69,6 @@ spec:
                 memory: 256Mi
         pod:
           securityContext:
-            runAsUser: 568
-            runAsGroup: 568
             runAsNonRoot: true
           topologySpreadConstraints:
             - maxSkew: 1


### PR DESCRIPTION
…ontext

The runAsUser and runAsGroup fields have been removed from the pod's securityContext in the cloudflared Helm release configuration. The runAsNonRoot field remains to ensure the pod runs as a non-root user.