### PR TITLE
feat(cloudflared): add security context for pod

### DIFF
--- a/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
+++ b/openshift/sno/apps/network/cloudflared/app/helmrelease.yaml
@@ -69,6 +69,8 @@ spec:
                 memory: 256Mi
         pod:
           securityContext:
+            runAsUser: 1000830000
+            runAsGroup: 1000830000
             runAsNonRoot: true
           topologySpreadConstraints:
             - maxSkew: 1


### PR DESCRIPTION
Added `runAsUser` and `runAsGroup` to the pod's security context to enhance security by specifying a non-root user and group. This change ensures the pod runs with the specified user and group IDs, aligning with best practices for running containers securely.