### PR TITLE
chore: update security context user and group IDs

### DIFF
--- a/openshift/sno/apps/infra/netbox/app/helmrelease.yaml
+++ b/openshift/sno/apps/infra/netbox/app/helmrelease.yaml
@@ -32,10 +32,10 @@ spec:
       - secretRef:
           name: netbox-secret
     podSecurityContext:
-      fsGroup: 1000830001
+      fsGroup: 1000770000
     securityContext:
-      runAsUser: 1000830001
-      runAsGroup: 1000830001
+      runAsUser: 1000770000
+      runAsGroup: 1000770000
       runAsNonRoot: true
       privileged: false
       readOnlyRootFilesystem: true
@@ -102,27 +102,27 @@ spec:
       enabled: false
     housekeeping:
       podSecurityContext:
-        fsGroup: 1000830001
+        fsGroup: 1000770000
       securityContext:
-        runAsUser: 1000830001
-        runAsGroup: 1000830001
+        runAsUser: 1000770000
+        runAsGroup: 1000770000
     init:
       image:
         repository: docker.io/library/busybox
         tag: 1.36.1
         pullPolicy: IfNotPresent
       securityContext:
-        runAsUser: 1000830001
-        runAsGroup: 1000830001
+        runAsUser: 1000770000
+        runAsGroup: 1000770000
     updateStrategy:
       type: RollingUpdate
     worker:
       enabled: true
       podSecurityContext:
-        fsGroup: 1000830001
+        fsGroup: 1000770000
       securityContext:
-        runAsUser: 1000830001
-        runAsGroup: 1000830001
+        runAsUser: 1000770000
+        runAsGroup: 1000770000
       updateStrategy:
         type: RollingUpdate
     resources:


### PR DESCRIPTION
Updated the fsGroup, runAsUser, and runAsGroup values in the podSecurityContext and securityContext sections from 1000830001 to 1000770000 for better alignment with security policies. This change affects the main application, housekeeping, init, and worker configurations.