### PR TITLE
chore(kustomization): comment out netbox resource

### DIFF
--- a/openshift/sno/apps/infra/kustomization.yaml
+++ b/openshift/sno/apps/infra/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  - ./netbox/ks.yaml
+  # - ./netbox/ks.yaml
   - ./vault/ks.yaml


### PR DESCRIPTION
Commented out the netbox resource in the kustomization.yaml file to prevent its inclusion in the build process. This change is intended to temporarily exclude netbox from the deployment.