### PR TITLE
fix(infra): include netbox configuration in kustomization

### DIFF
--- a/openshift/sno/apps/infra/kustomization.yaml
+++ b/openshift/sno/apps/infra/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
-  # - ./netbox/ks.yaml
+  - ./netbox/ks.yaml
   - ./vault/ks.yaml


### PR DESCRIPTION
The netbox configuration file (ks.yaml) is now included in the kustomization resources, enabling its deployment.