### PR TITLE
feat(netbox): add email_password field to externalsecret.yaml

### DIFF
--- a/openshift/sno/apps/infra/netbox/app/externalsecret.yaml
+++ b/openshift/sno/apps/infra/netbox/app/externalsecret.yaml
@@ -19,6 +19,7 @@ spec:
         superuser_password: "{{ .NETBOX_ADMIN_PASSWORD }}"
         superuser_api_token: "{{ .NETBOX_API_KEY }}"
         secret_key: "{{ .NETBOX_SECRET_KEY }}"
+        email_password: ""
         napalm_password: ""
         redis_tasks_password: ""
         redis_cache_password: ""


### PR DESCRIPTION
Added a new field `email_password` to the `externalsecret.yaml` file for the Netbox application. This change allows for the configuration of an email password within the external secret specification.