### PR TITLE
feat(cluster): add skipFSGroup option to cluster configuration

### DIFF
--- a/openshift/sno/apps/database/dragonfly/cluster/cluster.yaml
+++ b/openshift/sno/apps/database/dragonfly/cluster/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.23.1
   replicas: 1 # set to the number of nodes in the cluster
+  skipFSGroup: true
   env:
     - name: MAX_MEMORY
       valueFrom:


### PR DESCRIPTION
Added the skipFSGroup option to the cluster.yaml configuration file to enhance security settings. This change allows the cluster to skip setting the FSGroup for the pods, which can be beneficial in certain security contexts.