### PR TITLE
feat(netbox): disable Redis and configure external Redis instances

### DIFF
--- a/openshift/sno/apps/infra/netbox/app/helmrelease.yaml
+++ b/openshift/sno/apps/infra/netbox/app/helmrelease.yaml
@@ -88,7 +88,13 @@ spec:
     postgresql:
       enabled: false
     redis:
-      enabled: true
+      enabled: false
+    tasksRedis:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+    cachingRedis:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
     externalDatabase:
       host: postgres-rw.database.svc.cluster.local
       port: 5432


### PR DESCRIPTION
- Disabled the default Redis instance by setting `redis.enabled` to false.
- Configured `tasksRedis` with host `dragonfly.database.svc.cluster.local` and port `6379`.
- Configured `cachingRedis` with host `dragonfly.database.svc.cluster.local` and port `6379`.