### PR TITLE
feat(netbox): add route configuration

### DIFF
--- a/openshift/sno/apps/infra/netbox/app/kustomization.yaml
+++ b/openshift/sno/apps/infra/netbox/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./route.yaml

--- a/openshift/sno/apps/infra/netbox/app/route.yaml
+++ b/openshift/sno/apps/infra/netbox/app/route.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: netbox-route
+  annotations:
+    cert-manager.io/issuer-kind: ClusterIssuer
+    cert-manager.io/issuer-name: letsencrypt-production
+spec:
+  host: "netbox.${SECRET_DOMAIN}"
+  to:
+    kind: Service
+    name: netbox
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
- Added route.yaml to define an OpenShift Route for Netbox.
- Updated kustomization.yaml to include the new route.yaml resource.
- Configured route with TLS termination and cert-manager annotations for Let's Encrypt.