### PR TITLE
refactor(route.yaml): remove cert-manager annotations

### DIFF
--- a/openshift/sno/apps/infra/netbox/app/route.yaml
+++ b/openshift/sno/apps/infra/netbox/app/route.yaml
@@ -3,9 +3,6 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: netbox-route
-  annotations:
-    cert-manager.io/issuer-kind: ClusterIssuer
-    cert-manager.io/issuer-name: letsencrypt-production
 spec:
   host: "netbox.${SECRET_DOMAIN}"
   to:


### PR DESCRIPTION
Removed the cert-manager.io annotations for issuer-kind and issuer-name from the netbox-route in the route.yaml file. This change simplifies the route configuration by eliminating unnecessary certificate management settings.